### PR TITLE
Fixed gymnasium error

### DIFF
--- a/sr_dqn_lab/train_script.py
+++ b/sr_dqn_lab/train_script.py
@@ -1,6 +1,7 @@
 import os
 import gymnasium as gym
 import numpy as np
+import minigrid
 import argparse
 import matplotlib.pyplot as plt
 from stable_baselines3 import DQN


### PR DESCRIPTION
Fixed `gymnasium.error.NameNotFound: Environment `MiniGrid-DoorKey-5x5` doesn't exist.`